### PR TITLE
Add environment variable to optionally load cogs on startup

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@
 | `RPC_PORT`                | The port used by Red's RPC server, if enabled.                                          | string  | `6133`   |
 | `TEAM_MEMBERS_ARE_OWNERS` | Treat Discord Developers application team members as owners.                            | boolean | `false`  |
 | `PIP_REQUIREMENTS`        | Optional space-separated list of pip packages to install.                               | string  |          |
+| `LOAD_COGS`               | Optional space-separated list of cogs to load on startup.                               | string  |          |
 
 ### Additional Options
 

--- a/docker-compose-example.yml
+++ b/docker-compose-example.yml
@@ -13,5 +13,6 @@ services:
             # RPC_PORT: "6133"                  # Optional, default 6133
             # TEAM_MEMBERS_ARE_OWNERS: "false"  # Optional, default false
             # PIP_REQUIREMENTS: ""              # Optional, space-separated list of pip requirements, default empty
+            # LOAD_COGS: ""                     # Optional, space-separated list of exclusive cogs to load, default empty
         volumes:
             - /opt/redbot:/redbot/data

--- a/redbot/start-red.sh
+++ b/redbot/start-red.sh
@@ -25,6 +25,11 @@ if [ "$TEAM_MEMBERS_ARE_OWNERS" = 'true' ]; then
     ARGS="$ARGS --team-members-are-owners"
 fi
 
+# Only load the listed cogs when specified.
+if [ -n "$LOAD_COGS" ]; then
+    ARGS="$ARGS --no-cogs --load-cogs $LOAD_COGS"
+fi
+
 # Append any arguments passed from cmdline
 [ -n "$EXTRA_ARGS" ] && echo "ERROR: EXTRA_ARGS is no longer supported. See https://github.com/rHomelab/Red-DiscordBot-Docker#additional-options" && exit 1
 if [ -n "$@" ]; then


### PR DESCRIPTION
This change allows a list of cogs to always load upon startup, automating the loading of cogs for red.

When `LOAD_COGS` is specified, only the cogs listed will be loaded by runnning `--no-cogs --load-cogs <cogs>`.

## Changes

- Added optional env var `LOAD_COGS` to load cogs on startup