### PR TITLE
Fix error when multiple additional options are supplied

### DIFF
--- a/redbot/entrypoint.sh
+++ b/redbot/entrypoint.sh
@@ -4,4 +4,4 @@ set -e
 chown -R ${RED_USER}:${RED_USER} ${RED_HOME}/data
 
 # Install pip packages and start Red as specified user
-exec runuser -u $RED_USER -- ${RED_HOME}/start-red.sh "$@"
+exec runuser -u $RED_USER -- ${RED_HOME}/start-red.sh $@

--- a/redbot/entrypoint.sh
+++ b/redbot/entrypoint.sh
@@ -4,4 +4,4 @@ set -e
 chown -R ${RED_USER}:${RED_USER} ${RED_HOME}/data
 
 # Install pip packages and start Red as specified user
-exec runuser -u $RED_USER -- ${RED_HOME}/start-red.sh $@
+exec runuser -u $RED_USER -- ${RED_HOME}/start-red.sh "$@"

--- a/redbot/start-red.sh
+++ b/redbot/start-red.sh
@@ -27,9 +27,7 @@ fi
 
 # Append any arguments passed from cmdline
 [ -n "$EXTRA_ARGS" ] && echo "ERROR: EXTRA_ARGS is no longer supported. See https://github.com/rHomelab/Red-DiscordBot-Docker#additional-options" && exit 1
-if [ -n "$@" ]; then
-    ARGS="$ARGS $@"
-fi
+ARGS="$ARGS $@"
 
 if [ -n "$PIP_REQUIREMENTS" ]; then
     echo "Installing pip packages: $PIP_REQUIREMENTS"


### PR DESCRIPTION
The [additional options section](https://github.com/rHomelab/Red-DiscordBot-Docker/blob/main/README.md#additional-options) of the readme implies that multiple additional options can be supplied to a container running this image. However when doing so, an error is show in the logs, but red continues to start up with the additional arguments being ignored.

This is due to a [bug in the entrypoint script](https://github.com/rHomelab/Red-DiscordBot-Docker/blob/main/redbot/entrypoint.sh#L7C55-L7C57) which doesn't expand the args.

This means that `--mentionable` or `--no-cogs` works.
![image](https://github.com/rHomelab/Red-DiscordBot-Docker/assets/46600706/328ad906-1e33-44a1-8667-687d32158e37)

But `--load-cogs audio` or `--no-cogs --load-cogs=audio` doesn't.
![image](https://github.com/rHomelab/Red-DiscordBot-Docker/assets/46600706/fa4febfd-4805-4133-9380-726c3c211346)

Any space separated arguments will fail and the container will still go up, but you'll see an unexpected operator error in the logs. 

>The issue is that $@ is treated as if it were a single string, while it is actually capable of storing multiple string elements in an array-like fashion when more than one argument is passed.

## Changes
- Expand arguments on entrypoint script