### PR TITLE
fix: use tini and exec for proper signal handling

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN groupadd -r -g $RED_GID ${RED_USER} && \
 COPY redbot/requirements.txt ${RED_HOME}/
 
 RUN apt update && \
-   apt --no-install-recommends -y install build-essential git openjdk-11-jre-headless units && \
+   apt --no-install-recommends -y install build-essential git openjdk-11-jre-headless units tini && \
    su $RED_USER -c "python -m pip install --no-cache-dir --user -r ${RED_HOME}/requirements.txt" && \
    apt remove -y build-essential && \
    apt autoremove -y && \
@@ -30,4 +30,4 @@ COPY --chmod=755 redbot/*.sh ${RED_HOME}/
 
 VOLUME ["${RED_HOME}/data"]
 
-ENTRYPOINT ["/redbot/entrypoint.sh"]
+ENTRYPOINT ["/usr/bin/tini", "--", "/redbot/entrypoint.sh"]

--- a/redbot/entrypoint.sh
+++ b/redbot/entrypoint.sh
@@ -3,5 +3,5 @@ set -e
 
 chown -R ${RED_USER}:${RED_USER} ${RED_HOME}/data
 
-# Install pip packages and start Red as specified user
-exec runuser -u $RED_USER -- ${RED_HOME}/start-red.sh $@
+# Start Red launch script as specified user
+exec runuser -u $RED_USER -- ${RED_HOME}/start-red.sh "$@"

--- a/redbot/start-red.sh
+++ b/redbot/start-red.sh
@@ -51,4 +51,4 @@ else
     echo "Found Red instance '$INSTANCE_NAME'. Starting..."
 fi
 
-redbot $ARGS
+exec redbot $ARGS


### PR DESCRIPTION
This allows Red to shut down safely when the container is stopped. This has never worked before. Whoops :)

- Execute entrypoint script with `tini`
- Start `redbot` with `exec`